### PR TITLE
Add simple Dario layout style

### DIFF
--- a/_layouts/dario.liquid
+++ b/_layouts/dario.liquid
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    {% include head.liquid %}
+    {% if page._styles %}
+      <style type="text/css">
+        {{ page._styles }}
+      </style>
+    {% endif %}
+  </head>
+  <body class="{% if site.navbar_fixed %}fixed-top-nav{% endif %} {% unless site.footer_fixed %}sticky-bottom-footer{% endunless %}">
+    {% include header.liquid %}
+    <main class="dario-post">
+      <article>
+        <header>
+          <h1>{{ page.title }}</h1>
+          <p>{{ page.description }}</p>
+        </header>
+        {{ content }}
+      </article>
+    </main>
+    {% include footer.liquid %}
+    {% include scripts.liquid %}
+  </body>
+</html>

--- a/_sass/_dario.scss
+++ b/_sass/_dario.scss
@@ -1,0 +1,16 @@
+body {
+  font-family: 'Georgia', 'Times New Roman', serif;
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 2rem;
+  background-color: #ffffff;
+  color: #222222;
+}
+h1, h2, h3, h4, h5, h6 {
+  color: #111111;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+a {
+  color: #0076df;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -12,6 +12,7 @@ $max-content-width: {{ site.max_width }};
   "layout",
   "base",
   "distill",
+  "dario",
   "cv",
   "tabs",
   "typograms",


### PR DESCRIPTION
## Summary
- add a new Dario style layout
- import a new SCSS partial for the style
- wire the partial into the main stylesheet

## Testing
- `bundle exec jekyll build` *(fails: Could not find jekyll-paginate-v2-3.0.0, jekyll-scholar-7.2.0, jekyll-sitemap-1.4.0, jekyll-toc-0.19.0, jemoji-0.13.0 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_684651cffd80832d9aeeea4c32b16e8e