### PR TITLE
Tweak Dario layout margin and font

### DIFF
--- a/_layouts/dario.liquid
+++ b/_layouts/dario.liquid
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    {% include head.liquid %}
+    {% if page._styles %}
+      <style type="text/css">
+        {{ page._styles }}
+      </style>
+    {% endif %}
+  </head>
+  <body class="{% if site.navbar_fixed %}fixed-top-nav{% endif %} {% unless site.footer_fixed %}sticky-bottom-footer{% endunless %}">
+    {% include header.liquid %}
+    <main class="dario-post">
+      <article>
+        <header>
+          <h1>{{ page.title }}</h1>
+          <p>{{ page.description }}</p>
+        </header>
+        {{ content }}
+      </article>
+    </main>
+    {% include footer.liquid %}
+    {% include scripts.liquid %}
+  </body>
+</html>

--- a/_sass/_dario.scss
+++ b/_sass/_dario.scss
@@ -1,0 +1,27 @@
+.dario-post {
+  font-family: 'Georgia Pro', Georgia, 'Times New Roman', serif;
+  max-width: $max-content-width;
+  margin: 3rem auto;
+  padding: 2rem;
+  background-color: var(--global-bg-color);
+  color: var(--global-text-color);
+}
+
+.dario-post h1,
+.dario-post h2,
+.dario-post h3,
+.dario-post h4,
+.dario-post h5,
+.dario-post h6 {
+  color: var(--global-text-color);
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.dario-post a {
+  color: var(--global-theme-color);
+
+  &:hover {
+    color: var(--global-hover-color);
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -12,6 +12,7 @@ $max-content-width: {{ site.max_width }};
   "layout",
   "base",
   "distill",
+  "dario",
   "cv",
   "tabs",
   "typograms",


### PR DESCRIPTION
## Summary
- expand Dario post container to site max width
- use Georgia Pro fonts
- styles remain scoped to `.dario-post`

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684651cffd80832d9aeeea4c32b16e8e